### PR TITLE
Fix reference to frei.funk #26

### DIFF
--- a/www/participate/howto/flash.html
+++ b/www/participate/howto/flash.html
@@ -33,7 +33,7 @@ Falls du dir schon deine [IP-Adressen registriert](http://config.berlin.freifunk
 ### 3. Firmware einspielen
 Jetzt kannst du den Router einfach über den Browser konfigurieren.
 
-Dazu rufst du in deinen Browser folgende Adresse auf: <a href="http://frei.funk" target="_blank">http://frei.funk</a>
+Dazu rufst du in deinen Browser folgende Adresse auf: **<http://192.168.0.1>** 
 
 Bevor du weitermachst, musst du dich erst anmelden. Die wenig inspirierte Username / Passwort Kombination ist: **admin** / **admin**
 


### PR DESCRIPTION
After starting a brand new router with original firmware, it does not habe the frei.funk dns
entry.
