### PR TITLE
Svg heights fixed to 352px in Network/Stats to avoid problems in firefox...

### DIFF
--- a/www/network/stats.html
+++ b/www/network/stats.html
@@ -95,7 +95,7 @@ var drawNodes = function(nodes) {
     var svg = d3.select(id).append("svg")
           .data([data])
           .attr("width", "100%")
-          .attr("height", "100%")
+          .attr("height", "353px")
           .style("display", "none");
 
     var transX = r + 10,


### PR DESCRIPTION
... as well as different svg sizes in Chrome - depending on your window size it hid away good parts of the svg
