### PR TITLE
cron_pull.sh: use virtual environment if one exists

### DIFF
--- a/bin/cron_pull.sh
+++ b/bin/cron_pull.sh
@@ -14,9 +14,15 @@ cd ${GIT_TARGET_DIR}
 
 #generate website
 cd ${GIT_TARGET_DIR}/www
-/usr/local/bin/cyrax -q -d ${WWW_TARGET_DIR}
+
+# activate virtual environment if one exists
+if [ -e "${GIT_TARGET_DIR}/env/bin/activate" ]; then
+  . "${GIT_TARGET_DIR}/env/bin/activate"
+fi
+
+CYRAX=$(which cyrax)
+$CYRAX -q -d ${WWW_TARGET_DIR}
 
 exit 0
 
 #EOF
-


### PR DESCRIPTION
Some people prefer to install packages like cyrax in a virtual environment. This
change tests for a virtual environment (env) inside the git directory of
berlin.freifunk.net. If the env exists we activate the env.

I need this to make the deployment process compatible with puppet.

This change should not break existing functionality.

@egmont1227 @cholin what do you think?