### PR TITLE
add calender feed

### DIFF
--- a/www/static/berlin.json
+++ b/www/static/berlin.json
@@ -41,9 +41,17 @@
             "Public Free Wifi",
             "Free internet access"
         ],
-        "lastchange":"2017-01-08T18:00:01.787518Z",
+        "lastchange":"2017-02-14T17:52:01.787518Z",
         "nodes":598
     },
+    "feeds": [
+        {
+            "name": "berlin calendar",
+            "category": "ics",
+            "type": "ics",
+            "url": "https://ics.freifunk.net/tags/berlin.ics"
+        }
+    ],
     "techDetails":{
         "firmware":{
             "docs":"https://wiki.freifunk.net/Berlin:Firmware",


### PR DESCRIPTION

events for berlin can be added/edited with tag berlin at https://ics.freifunk.net/tags/berlin. 