### PR TITLE
add current mailinglist/wiki topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _build/
 .*.swp
+www/external_news_list.html
+www/external_news_wiki.html

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 build_dir = 'www'
 hook_dir = '.git/hooks'
 
-generate:
+generate: build_news
 	cd $(build_dir) && cyrax -v
 
-webserver:
+webserver: build_news
 	cd $(build_dir) && cyrax -wv
+
+build_news:
+	cd $(build_dir) && \
+	php ../bin/external_news.php ffwiki > external_news_wiki.html && \
+	php ../bin/external_news.php fflist > external_news_list.html
 
 deploy:
 	bin/deploy

--- a/README
+++ b/README
@@ -1,10 +1,16 @@
 Freifunk Berlin
 ===============
+https://github.com/freifunk-berlin/berlin.freifunk.net
+https://berlin.freifunk.net
+
+The website is built using the static site generator
+Cyrax (https://github.com/piranha/cyrax).
+Current mailinglist/wiki topics are pulled by a small
+PHP command line script.
 
   $ git clone git://github.com/freifunk/berlin.freifunk.net.git
   $ cd berlin.freifunk.net
   $ pip install cyrax markdown2
-  $ cd www
-  $ cyrax -vw
+  $ make webserver
 
-Live: https://berlin.freifunk.net
+Hosted on Monoro by nosy. Updated from git via hourly cronjob.

--- a/bin/external_news.php
+++ b/bin/external_news.php
@@ -1,0 +1,74 @@
+<?php
+
+// Generate HTML snippets that list topics from various external sites.
+
+// We want to advertise external resources and give an overview of recent topics.
+// We don't want users to use these snippets as main entry point to external sites
+// or provide deep links (that would be quite a link list, plus we do not want to
+// link to "Re: Re: Re: a question" mailinglist postings).
+// So this really just lists topics, not links.
+
+function getHtml($url) {
+  $ch = curl_init();
+  curl_setopt($ch, CURLOPT_URL, $url);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+  curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+  curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+  $result = curl_exec($ch);
+  curl_close($ch);
+  return $result;
+}
+
+if(in_array("fflist", $argv)) {
+  // FF Berlin mailinglist
+
+  $listArchiveUrl = "https://lists.berlin.freifunk.net/pipermail/berlin/";
+  // Find newest archive page
+  $listHtml = getHtml($listArchiveUrl);
+  preg_match("/Herunterladbare Version.*?<A href=\"(.*?)\"/s", $listHtml, $matches);
+  $listNewestUrl = $listArchiveUrl.str_replace("thread", "date", $matches[1]);
+  //echo $listNewestUrl;
+
+  // Find postings
+  $listHtml = getHtml($listNewestUrl);
+  preg_match_all("/<A HREF=\"(\d\d\d\d\d\d.html)\">\[Berlin-wireless\] (.*?)<\/A>/s", $listHtml, $matches);
+  //print_r($matches[2]);
+
+  // Create topic list
+  $topicList = "";
+  foreach(array_reverse($matches[2]) as $match) {
+    if(strpos($match, "Berlin Nachrichtensammlung")===0) continue;
+    if(strpos($topicList, substr($match, 0, 10))===FALSE) {
+      if(strlen($topicList)>300) break;
+      if(strlen($topicList)>0) $topicList .= "&nbsp;• ";
+      $topicList .= trim($match);
+    }
+  }
+  echo $topicList;
+}
+
+if(in_array("ffwiki", $argv)) {
+  // wiki.freifunk.net
+
+  $wikiRecentUrl = "https://wiki.freifunk.net/index.php?title=Spezial:Letzte_%C3%84nderungen&days=30&from=&limit=500";
+  // Find recent changes of "Berlin:" pages
+  $wikiHtml = getHtml($wikiRecentUrl);
+  //<a href="/Berlin:Firmware" title="Berlin:Firmware" class="mw-changeslist-title">Berlin:Firmware</a>
+  preg_match_all("/<a href=\"(\/Berlin:.*?)\".*?>(.*?)<\/a>/", $wikiHtml, $matches);
+  //print_r($matches[2]);
+
+  // Create wiki topic list
+  $topicList = "";
+  foreach($matches[2] as $match) {
+    if(strlen($match)<5) continue;
+    if(strpos($topicList, $match)===FALSE) {
+      if(strlen($topicList)>300) break;
+      if(strlen($topicList)>0) $topicList .= "&nbsp;• ";
+      $topicList .= trim($match);
+    }
+  }
+  echo $topicList;
+}
+
+?>

--- a/bin/external_news.php
+++ b/bin/external_news.php
@@ -16,7 +16,12 @@ function getHtml($url) {
   curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
   curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
   $result = curl_exec($ch);
+  $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
   curl_close($ch);
+  if($code!=200) {
+    echo("failed to fetch $url (HTTP error $code)");
+    exit(1);
+  }
   return $result;
 }
 
@@ -39,10 +44,11 @@ if(in_array("fflist", $argv)) {
   $topicList = "";
   foreach(array_reverse($matches[2]) as $match) {
     if(strpos($match, "Berlin Nachrichtensammlung")===0) continue;
+    $match = trim($match);
     if(strpos($topicList, substr($match, 0, 10))===FALSE) {
       if(strlen($topicList)>300) break;
       if(strlen($topicList)>0) $topicList .= "&nbsp;• ";
-      $topicList .= trim($match);
+      $topicList .= str_replace("<", "&lt;", $match);
     }
   }
   echo $topicList;
@@ -62,10 +68,11 @@ if(in_array("ffwiki", $argv)) {
   $topicList = "";
   foreach($matches[2] as $match) {
     if(strlen($match)<5) continue;
+    $match = trim($match);
     if(strpos($topicList, $match)===FALSE) {
       if(strlen($topicList)>300) break;
       if(strlen($topicList)>0) $topicList .= "&nbsp;• ";
-      $topicList .= trim($match);
+      $topicList .= str_replace("<", "&lt;", $match);
     }
   }
   echo $topicList;

--- a/www/index.html
+++ b/www/index.html
@@ -66,5 +66,12 @@
   </p>
 </div>
 
+<div id="news">
+  <h3>Aktuelles</h3>
+  <p><b>Letzte Themen auf der <a href="https://lists.berlin.freifunk.net/pipermail/berlin/" class="externalLink">Berliner Mailingliste</a></b>
+  <br/><em>{% include 'external_news_list.html' %}</em></p>
+  <p><b>Letzte Berlin-spezifische Änderungen auf <a href="https://wiki.freifunk.net/index.php?title=Spezial:Letzte_%C3%84nderungen&amp;days=30&amp;from=&amp;limit=500" class="externalLink">wiki.freifunk.net</a></b>
+  <br/><em>{% include 'external_news_wiki.html' %}</em></p>
+</div>
 
 {% endblock %}

--- a/www/index_en.html
+++ b/www/index_en.html
@@ -63,5 +63,13 @@
   </p>
 </div>
 
+<div id="news">
+  <h3>Current Activity</h3>
+  <p><b>Current topics on the <a href="https://lists.berlin.freifunk.net/pipermail/berlin/" class="externalLink">Berlin mailing list</a></b>
+  <br/><em>{% include 'external_news_list.html' %}</em></p>
+  <p><b>Recent Berlin specific changes on <a href="https://wiki.freifunk.net/index.php?title=Spezial:Letzte_%C3%84nderungen&amp;days=30&amp;from=&amp;limit=500" class="externalLink">wiki.freifunk.net</a></b>
+  <br/><em>{% include 'external_news_wiki.html' %}</em></p>
+</div>
+
 
 {% endblock %}

--- a/www/wiki.html
+++ b/www/wiki.html
@@ -20,5 +20,9 @@ Im Folgenden ein paar gute Einstiegspunkte:
 </ul>
 Mach mit!
 </p>
+<p>
+<b>Die letzten Berlin-spezifischen <a href="https://wiki.freifunk.net/index.php?title=Spezial:Letzte_%C3%84nderungen&amp;days=30&amp;from=&amp;limit=500" class="externalLink">Änderungen im Wiki</a> gingen um die Themen...</b>
+<br/><em>{% include 'external_news_wiki.html' %}</em>
+</p>
 
 {% endblock %}


### PR DESCRIPTION
This uses a small PHP script (that will be run on the server in
its hourly cronjob) to scrape recent topics from the mailinglist
and wiki server.

Code's not beautiful but not the nightmare to maintain that a Cyrax plugin would be; it's not as brittle as a JavaScript client solution would be; and it's more hackable than an RSS-based solution would be (it's already doing some filtering that would be difficult with RSS).

I'll be merging this soon.