### PR TITLE
move Hopglass-map to 1st place

### DIFF
--- a/www/network/_utils.html
+++ b/www/network/_utils.html
@@ -1,8 +1,8 @@
 {% macro render_subnav() -%}
       <ul class="span12 submenu">
         {% import '_utils.html' as utils with context%}
-        {{ utils.nav('Karte (OWM)', 'network/map') }}
         {{ utils.nav_external('Karte (Hopglass)', 'https://hopglass.berlin.freifunk.net/') }}
+        {{ utils.nav('Karte (OWM)', 'network/map') }}
         {{ utils.nav('Knoten', 'network/nodes') }}
         {{ utils.nav('Statistik', 'network/stats') }}
         {{ utils.nav_external('Monitor', 'http://monitor.berlin.freifunk.net') }}


### PR DESCRIPTION
Hopglass has become somewhat independent from OWM as datasource with https://github.com/freifunk-berlin/hopglass.berlin.freifunk.net/commit/97b044763e16cce9585e4cf8e548491e0baaeb70. In the past weeks we had often seen 500-errors on the OWM.
So move the more reliable hopglass in 1st position.

Any Ideas, how to integrate hopgalss into "www/network/map.html", that it displays when loading https://berlin.freifunk.net/network/map/?