### PR TITLE
WIP: Make hopglass default map due to regular crashes on OWM.

### DIFF
--- a/www/network/_utils.html
+++ b/www/network/_utils.html
@@ -1,8 +1,8 @@
 {% macro render_subnav() -%}
       <ul class="span12 submenu">
         {% import '_utils.html' as utils with context%}
-        {{ utils.nav_external('Karte (Hopglass)', 'https://hopglass.berlin.freifunk.net/') }}
-        {{ utils.nav('Karte (OWM)', 'network/map') }}
+        {{ utils.nav('Karte (Hopglass)', 'network/map') }}
+        {{ utils.nav('Karte (OWM)', 'network/mapOWM') }}
         {{ utils.nav('Knoten', 'network/nodes') }}
         {{ utils.nav('Statistik', 'network/stats') }}
         {{ utils.nav_external('Monitor', 'http://monitor.berlin.freifunk.net') }}

--- a/www/network/map.html
+++ b/www/network/map.html
@@ -4,9 +4,9 @@
 {% endmeta %}
 
 {% block content %}
-<a class="pull-right" href="http://openwifimap.net/#map?bbox=52.449,13.1777,52.587,13.625">
+<a class="pull-right" href="https://hopglass.berlin.freifunk.net/">
   Vollbild
 </a>
 
-<iframe id="map" src="//openwifimap.net/#map?bbox=52.449,13.1777,52.587,13.625" width="100%" height="600px" frameborder="0"></iframe>
+<iframe id="map" src="//hopglass.berlin.freifunk.net/" width="100%" height="600px" frameborder="0"></iframe>
 {% endblock %}

--- a/www/network/mapOWM.html
+++ b/www/network/mapOWM.html
@@ -1,0 +1,11 @@
+{% meta %}
+  parent_tmpl: network/_layout.html
+{% endmeta %}
+
+{% block content %}
+<a class="pull-right" href="http://openwifimap.net/#map?bbox=52.449,13.1777,52.587,13.625">
+  Vollbild
+</a>
+
+<iframe id="mapOWM" src="//openwifimap.net/#map?bbox=52.449,13.1777,52.587,13.625" width="100%" height="600px" frameborder="0"></iframe>
+{% endblock %}


### PR DESCRIPTION
This MR changes the default map on https://berlin.freifunk.net/network/map/ to hopglass, as OWM crashes regularly.

Details:
- The former link to hopglass now leads to a local page which includes Hopglass into a frame, similar to OWM. (see picture 1). This is the standard page loaded, when clicking on _Netzkarte_
- The OWM-page is preserved.

There is some little flaw:
- When loading the owm-page, the links _Netzkarte_ and _Karte (OWM)_ in the navigation menue aren't marked anymore. But this doesn't seem to affect the proper function either. (picture 2)

picture1:
![Screenshot_20200618_165552](https://user-images.githubusercontent.com/43141307/85038216-9f9fb780-b186-11ea-8947-ac71af51f881.png)

picture2:
![Screenshot_20200618_165614](https://user-images.githubusercontent.com/43141307/85038222-a29aa800-b186-11ea-9199-6e6c52a887d1.png)


@sarumpaet 
@booo 