### PR TITLE
HowTo: Adjust all links to point to rewritten Firmware-HowTo.

### DIFF
--- a/www/downloads.html
+++ b/www/downloads.html
@@ -13,7 +13,7 @@
   gibt dir die bei der Einrichtung benötigten IPs.
 </p>
 <p>
-  Der genaue Vorgang zur Einrichtung ist im Wiki-Artikel <a href="https://wiki.freifunk.net/Berlin:Firmware:Howto" class="externalLink">Berlin:Firmware:Howto</a> beschrieben.
+  Der genaue Vorgang zur Einrichtung ist im Wiki-Artikel <a href="https://wiki.freifunk.net/Berlin:Firmware/HowTo" class="externalLink">Berlin:Firmware/HowTo</a> beschrieben.
 </p>
 
 <p>

--- a/www/participate/_layout.html
+++ b/www/participate/_layout.html
@@ -7,7 +7,7 @@
       <ul class="span12 submenu">
         {% import '_utils.html' as utils with context%}
         {{ utils.nav('Überblick', 'participate/overview') }}
-        {{ utils.nav_external('HowTo', 'https://wiki.freifunk.net/Berlin:Firmware:Howto') }}
+        {{ utils.nav_external('HowTo', 'https://wiki.freifunk.net/Berlin:Firmware/HowTo') }}
         {{ utils.nav('Spenden', 'participate/donate') }}
         {{ utils.nav_external('Freifunk-Wizard', 'https://config.berlin.freifunk.net/wizard/routers') }}
         {{ utils.nav_external('BBB-VPN', 'https://wiki.freifunk.net/Berlin:BBB-VPN') }}

--- a/www/participate/howto/config.html
+++ b/www/participate/howto/config.html
@@ -5,7 +5,7 @@ parent_tmpl: participate/_layout.html
 {% block content %}
 {% filter markdown %}
 
-Das HowTo findet sich inzwischen im Wiki-Artikel [Berlin:Firmware:Howto](https://wiki.freifunk.net/Berlin:Firmware:Howto).
+Das HowTo findet sich inzwischen im Wiki-Artikel [Berlin:Firmware/HowTo](https://wiki.freifunk.net/Berlin:Firmware/HowTo).
 
 {% endfilter %}
 {% endblock %}

--- a/www/participate/howto/flash.html
+++ b/www/participate/howto/flash.html
@@ -7,7 +7,7 @@
 <div id="howto">
 {% filter markdown %}
 
-Das HowTo findet sich inzwischen im Wiki-Artikel [Berlin:Firmware:Howto](https://wiki.freifunk.net/Berlin:Firmware:Howto).
+Das HowTo findet sich inzwischen im Wiki-Artikel [Berlin:Firmware/HowTo](https://wiki.freifunk.net/Berlin:Firmware/HowTo).
 
 {% endfilter %}
 </div>

--- a/www/participate/howto/index.html
+++ b/www/participate/howto/index.html
@@ -7,7 +7,7 @@ parent_tmpl: participate/_layout.html
 
 {% filter markdown %}
 
-Das HowTo findet sich inzwischen im Wiki-Artikel [Berlin:Firmware:Howto](https://wiki.freifunk.net/Berlin:Firmware:Howto).
+Das HowTo findet sich inzwischen im Wiki-Artikel [Berlin:Firmware/HowTo](https://wiki.freifunk.net/Berlin:Firmware/HowTo).
 
 Falls du Fragen hast, kannst du dich jederzeit an unsere [Mailingliste](http://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin) wenden oder zu einem unserer [Treffen]({{url_for('contact')}}) kommen.
 


### PR DESCRIPTION
This MR changes all links for the HowTo in the freifunk wiki to point to the rewritten Version.