### PR TITLE
donate.html: Include new better-place-campaing, make broken iframes o…

### DIFF
--- a/www/participate/donate.html
+++ b/www/participate/donate.html
@@ -9,16 +9,24 @@
 
 <p>
   Für den Aufbau und Erhalt unseres freien Funknetzwerks sind wird auf
-  regelmäßige Spenden angewiesen. Alle Spenden werden vom <a
-    href="http://foerderverein.freie-netzwerke.de/" class="externalLink">
-  Förderverein freie Netzwerke e.V.</a> bearbeitet. Der Verein bevorzugt Spenden über
-  Betterplace. Zuwendungsbescheide können vom Verein ausgestellt werden.
+  regelmäßige Spenden angewiesen. Wir bevorzugen Spenden über betterplace.org. Das ist
+  sowohl für uns, als auch für euch einfacher. Spendenbescheinigungen werden von betterplace.org 
+  ausgestellt und im Februar des Folgejahres verschickt.
+  <br><br>
   Ihr könnt Freifunk Berlin auf verschiedenen Wegen eure Geld-Spende zukommen
   lassen:
 </p>
 
 <h4>Betterplace:</h4>
 
+<iframe frameborder="0" marginheight="0" marginwidth="0"
+  src="https://www.betterplace-widget.org/projects/83703?l=de"
+  width="100%" height="320" style="border: 0; padding:0; margin:0;"
+  >Informieren und spenden: <a href='https://www.betterplace.org/de/projects/83703-freifunk-berlin-im-haus-der-statistik'
+  target='_blank'>„Freifunk Berlin im Haus der Statistik“</a> auf betterplace.org öffnen.
+</iframe>
+
+<!--
 <iframe style="border: 0; padding: 0; margin: 0;"
   src="http://www.betterplace.org/de/projects/14418-berlin-freifunk-net/widget"
   height="260" width="160" frameborder="0" marginwidth="0"
@@ -30,6 +38,7 @@
   height="260" width="160" frameborder="0" marginwidth="0"
   marginheight="0">
 </iframe>
+-->
 
 <h4>Flattr:</h4>
 <a href="https://flattr.com/submit/auto?user_id=freifunk&url=http://freifunk.net&title=Freifunk%20Berlin&description=Freifunk%20is%20a%20non-commercial%20initiative%20for%20free%20decentraliced%20wireless%20mesh%20networks.&language=de_DE&tags=distributed,wifi,mesh,openwrt,olsr&category=software">


### PR DESCRIPTION
This commit introduces the donation campaign for the Freifunk-Room at HdS into the website. At the same time it solves #68 (partly) by commenting the broken iframes out. To include newly, perfect working iframes, we need to contact the Förderverein. They need to provide a code snippet, which they can obtain from betterplace.org