### PR TITLE
fix typo in howto-link

### DIFF
--- a/www/participate/overview.html
+++ b/www/participate/overview.html
@@ -58,7 +58,7 @@ Alle können Freifunker_innen werden! Wir freuen uns über Unterstützung bei
             Bei der Entscheidung, welchen Router du für Freifunk besorgen solltest, gibt es im Artikel <a href="https://wiki.freifunk.net/Berlin:Firmware#Unterst.C3.BCtzte_Router" class="externalLink">Berlin:Firmware</a> des <a href="{{url_for('wiki')}}">Wikis</a> Hilfestellung.
           </li>
           <li>
-            Gehe wie im Artikel <a href="https://wiki.freifunk.net/Berlin:Firmware/Howto" class="externalLink">Berlin:Firmware:Howto</a> beschrieben vor, um die Firmware zu flashen und zu konfigurieren.
+            Gehe wie im Artikel <a href="https://wiki.freifunk.net/Berlin:Firmware/HowTo" class="externalLink">Berlin:Firmware:HowTo</a> beschrieben vor, um die Firmware zu flashen und zu konfigurieren.
           </li>
           <li>Stelle den Router an einem geeigneten Ort auf (z.B. Fensterbank).</li>
         </ul>


### PR DESCRIPTION
fixes a typo which prevented from finding the right wiki page.