### PR TITLE
Apache: add 301 redirects for old URLs

### DIFF
--- a/apache/website.conf
+++ b/apache/website.conf
@@ -1,51 +1,82 @@
 <VirtualHost *:80>
-   	ServerName berlin.freifunk.net
- 	ServerAdmin "info@berlin.freifunk.net"
+        ServerName berlin.freifunk.net
+        ServerAdmin "info@berlin.freifunk.net"
 
         DocumentRoot /var/www/404
 
         RewriteEngine On
         RewriteCond %{REQUEST_URI} !^/.well-known/
+        RewriteRule ^/$ https://berlin.freifunk.net/de/ [R=301,L]
+        RewriteRule ^/index_en/$ https://berlin.freifunk.net/en/ [R=301,L]
+        RewriteRule ^/network/map/$ https://berlin.freifunk.net/de/map/ [R=301,L]
+        RewriteRule ^/contact/$ https://berlin.freifunk.net/de/contact/ [R=301,L]
+        RewriteRule ^/downloads/$ https://berlin.freifunk.net/de/downloads/ [R=301,L]
+        RewriteRule ^/participate/overview/$ https://berlin.freifunk.net/de/participate/ [R=301,L]
+        RewriteRule ^/participate/howto/$ https://berlin.freifunk.net/de/participate/ [R=301,L]
+        RewriteRule ^/impressum/$ https://berlin.freifunk.net/de/impressum/ [R=301,L]
         RewriteRule .* https://berlin.freifunk.net%{REQUEST_URI} [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>
 	ServerName www.berlin.freifunk.net
-   	ServerAdmin "info@berlin.freifunk.net"
+        ServerAdmin "info@berlin.freifunk.net"
 	SSLEngine on
         SSLCertificateFile      /etc/letsencrypt/live/www.berlin.freifunk.net/cert.pem
         SSLCertificateChainFile /etc/letsencrypt/live/www.berlin.freifunk.net/chain.pem
         SSLCertificateKeyFile   /etc/letsencrypt/live/www.berlin.freifunk.net/privkey.pem
 
-  	Redirect 301 / https://berlin.freifunk.net/
+        RewriteEngine On
+        RewriteCond %{REQUEST_URI} !^/.well-known/
+        RewriteRule ^/$ https://berlin.freifunk.net/de/ [R=301,L]
+        RewriteRule ^/index_en/$ https://berlin.freifunk.net/en/ [R=301,L]
+        RewriteRule ^/network/map/$ https://berlin.freifunk.net/de/map/ [R=301,L]
+        RewriteRule ^/contact/$ https://berlin.freifunk.net/de/contact/ [R=301,L]
+        RewriteRule ^/downloads/$ https://berlin.freifunk.net/de/downloads/ [R=301,L]
+        RewriteRule ^/participate/overview/$ https://berlin.freifunk.net/de/participate/ [R=301,L]
+        RewriteRule ^/participate/howto/$ https://berlin.freifunk.net/de/participate/ [R=301,L]
+        RewriteRule ^/impressum/$ https://berlin.freifunk.net/de/impressum/ [R=301,L]
+
 </VirtualHost>
 
 <VirtualHost *:80>
 	ServerName www.berlin.freifunk.net
-   	ServerAdmin "info@berlin.freifunk.net"
+        ServerAdmin "info@berlin.freifunk.net"
 
-  	Redirect 301 / https://berlin.freifunk.net/
+        RewriteEngine On
+        RewriteCond %{REQUEST_URI} !^/.well-known/
+        RewriteRule .* https://berlin.freifunk.net/de/ [R=301,L]
 </VirtualHost>
 
 <VirtualHost *:443>
-   	ServerName berlin.freifunk.net
-   	ServerAdmin "info@berlin.freifunk.net"
+        ServerName berlin.freifunk.net
+        ServerAdmin "info@berlin.freifunk.net"
 	SSLEngine on
         SSLCertificateFile      /etc/letsencrypt/live/berlin.freifunk.net/cert.pem
         SSLCertificateChainFile /etc/letsencrypt/live/berlin.freifunk.net/chain.pem
         SSLCertificateKeyFile   /etc/letsencrypt/live/berlin.freifunk.net/privkey.pem
 
-   	DocumentRoot /var/www/berlin.freifunk.net/www
+        DocumentRoot /var/www/berlin.freifunk.net/www
+
+        RewriteEngine On
+        RewriteCond %{REQUEST_URI} !^/.well-known/
+        RewriteRule ^/$ https://berlin.freifunk.net/de/ [R=301,L]
+        RewriteRule ^/index_en/$ https://berlin.freifunk.net/en/ [R=301,L]
+        RewriteRule ^/network/map/$ https://berlin.freifunk.net/de/map/ [R=301,L]
+        RewriteRule ^/contact/$ https://berlin.freifunk.net/de/contact/ [R=301,L]
+        RewriteRule ^/downloads/$ https://berlin.freifunk.net/de/downloads/ [R=301,L]
+        RewriteRule ^/participate/overview/$ https://berlin.freifunk.net/de/participate/ [R=301,L]
+        RewriteRule ^/participate/howto/$ https://berlin.freifunk.net/de/participate/ [R=301,L]
+        RewriteRule ^/impressum/$ https://berlin.freifunk.net/de/impressum/ [R=301,L]
 
 	Header set Content-Security-Policy "script-src berlin.freifunk.net"
 	Header set Strict-Transport-Security "max-age=63072000; includeSubDomains"
 
-   	<Directory "/var/www/berlin.freifunk.net/www">
-      		Options FollowSymLinks
-      		AllowOverride None
-      		Require all granted
-   	</Directory>
+        <Directory "/var/www/berlin.freifunk.net/www">
+                Options FollowSymLinks
+                AllowOverride None
+                Require all granted
+        </Directory>
 
-   	ErrorLog "/var/log/apache2/berlin.freifunk.net-error.log"
-   	CustomLog "/var/log/apache2/berlin.freifunk.net-access.log" combined
+        ErrorLog "/var/log/apache2/berlin.freifunk.net-error.log"
+        CustomLog "/var/log/apache2/berlin.freifunk.net-access.log" combined
 </VirtualHost>


### PR DESCRIPTION
There are quite some old URLs that have external links. This PR adds redirects so those URLs are still accessible. In addition this adds a direct Redirect from to the /de/ page for some szenarious.