### PR TITLE
Fix dl and ml links

### DIFF
--- a/content/contact.de.md
+++ b/content/contact.de.md
@@ -19,8 +19,6 @@ Zur Kommunikation gibt es neben den Treffen auch öffentliche Mailinglisten. Auf
 
 * [Berlin Wireless](https://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin) Achtung: Stand September 2023 funktioniert die Anmeldung nicht. Bitte schreib eine Mail an <info@berlin.freifunk.net>. Berliner Freifunk-Liste (Stell dich hier der Community vor)
 * [Berlin Neukölln](https://lists.spline.inf.fu-berlin.de/mailman/listinfo/ff-nk) Kiezliste für Neukölln
-* [Berlin Treptow-Köpenick](https://www.geroedel.de/mailman/listinfo/freifunk-tk) Kiezliste für Treptow-Köpenick
-* [Berlin Spandau](https://www.geroedel.de/mailman/listinfo/ff-spandau) Kiezliste für Spandau
 * [WLANnews](https://lists.freifunk.net/mailman/listinfo/wlannews-freifunk.net) Neuigkeiten aus den Communities und Nachrichten zum Thema WLAN und freie Netze aus ganz Deutschland
 * [WLANware](https://lists.freifunk.net/mailman/listinfo/wlanware-freifunk.net) Technischer Austausch über WLAN-Hardware aus ganz Deutschland
 * [WLANtalk](https://lists.freifunk.net/mailman/listinfo/wlantalk-freifunk.net) Überregionale Liste zum Austausch zwischen den verschiedenen Freifunk-Communities

--- a/content/contact.de.md
+++ b/content/contact.de.md
@@ -18,7 +18,6 @@ Möglichkeiten, bei Freifunk mitzumachen, gibt es viele: als Netzwerker_in, Soft
 Zur Kommunikation gibt es neben den Treffen auch öffentliche Mailinglisten. Auf diesen trägst Du Dich selbst ein, indem die Deine Emailadresse angibst und in der folgenden Bestätigungsmail den Link klickst. Du kannst einstellen, ob Du jede Nachricht sofort oder eine tägliche Zusammenfassung bekommen möchtest.
 
 * [Berlin Wireless](https://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin) Achtung: Stand September 2023 funktioniert die Anmeldung nicht. Bitte schreib eine Mail an <info@berlin.freifunk.net>. Berliner Freifunk-Liste (Stell dich hier der Community vor)
-* [Berlin Neukölln](https://lists.spline.inf.fu-berlin.de/mailman/listinfo/ff-nk) Kiezliste für Neukölln
 * [WLANnews](https://lists.freifunk.net/mailman/listinfo/wlannews-freifunk.net) Neuigkeiten aus den Communities und Nachrichten zum Thema WLAN und freie Netze aus ganz Deutschland
 * [WLANware](https://lists.freifunk.net/mailman/listinfo/wlanware-freifunk.net) Technischer Austausch über WLAN-Hardware aus ganz Deutschland
 * [WLANtalk](https://lists.freifunk.net/mailman/listinfo/wlantalk-freifunk.net) Überregionale Liste zum Austausch zwischen den verschiedenen Freifunk-Communities

--- a/content/contact.en.md
+++ b/content/contact.en.md
@@ -17,8 +17,6 @@ We communicate not only face-to-face at the meetings but also through public mai
 
 * [Berlin Wireless](https://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin) Berlin's Freifunk list
 * [Berlin Neukölln](https://lists.spline.inf.fu-berlin.de/mailman/listinfo/ff-nk) Neighborhood's list for Berlin Neukölln
-* [Berlin Treptow-Köpenick](https://www.geroedel.de/mailman/listinfo/freifunk-tk) Neighborhood's list for Berlin Treptow-Köpenick
-* [Berlin Spandau](https://www.geroedel.de/mailman/listinfo/ff-spandau) Neighborhood's list for Berlin Spandau
 * [WLANnews](https://lists.freifunk.net/mailman/listinfo/wlannews-freifunk.net) Communities' news and news on wifi and free networks from Germany
 * [WLANware](https://lists.freifunk.net/mailman/listinfo/wlanware-freifunk.net) Technical discussions on wifi hardware from all over Germany
 * [WLANtalk](https://lists.freifunk.net/mailman/listinfo/wlantalk-freifunk.net) A transregional mailing list for communication between the individual Freifunk communities

--- a/content/contact.en.md
+++ b/content/contact.en.md
@@ -16,7 +16,6 @@ Time and date of the meetings of the Berlin Freifunk community can be found in t
 We communicate not only face-to-face at the meetings but also through public mailing lists. After registration with your e-mail address, you need to click the link in the confirmation mail. You can choose between instant message delivery and a daily digest.
 
 * [Berlin Wireless](https://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin) Berlin's Freifunk list
-* [Berlin Neukölln](https://lists.spline.inf.fu-berlin.de/mailman/listinfo/ff-nk) Neighborhood's list for Berlin Neukölln
 * [WLANnews](https://lists.freifunk.net/mailman/listinfo/wlannews-freifunk.net) Communities' news and news on wifi and free networks from Germany
 * [WLANware](https://lists.freifunk.net/mailman/listinfo/wlanware-freifunk.net) Technical discussions on wifi hardware from all over Germany
 * [WLANtalk](https://lists.freifunk.net/mailman/listinfo/wlantalk-freifunk.net) A transregional mailing list for communication between the individual Freifunk communities

--- a/content/downloads.de.md
+++ b/content/downloads.de.md
@@ -23,4 +23,4 @@ Die Entwicklung der Firmware findet auf [github.com/freifunk-berlin/falter-packa
 
 ### Weitere Downloads
 
-Unter [download.berlin.freifunk.net](https://download.berlin.freifunk.net/) finden sich diverse Videos, eBooks und Flyer.
+Unter [download-master.berlin.freifunk.net](https://download-master.berlin.freifunk.net/) finden sich diverse Videos, eBooks und Flyer.

--- a/content/downloads.en.md
+++ b/content/downloads.en.md
@@ -23,4 +23,4 @@ The firmware development takes place on [github.com/freifunk-berlin/falter-packa
 
 ### More downloads
 
-Various videos, eBooks and flyers can be found at [download.berlin.freifunk.net](https://download.berlin.freifunk.net/).
+Various videos, eBooks and flyers can be found at [download-master.berlin.freifunk.net](https://download-master.berlin.freifunk.net/).


### PR DESCRIPTION
This PR fixes #109 and #110 and removes the inactive neukoelln mailinglist as discussed at the community day.