### PR TITLE
Add proto personas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing
+
+It's great that you want to get involved. Here is some information to consider when working together and editing the content.
+
+## Coordination
+
+We coordinate the work in the [issues](https://github.com/freifunk-berlin/berlin.freifunk.net/issues) and in the [matrix channel](https://matrix.to/#/!GoqhUqFUgbZdMGZGvf:matrix.org).
+New features should be created inside a feature-branch and introduced via a pull request. At least one approval is required. There is a test site for every branch at `https://dev.berlin.freifunk.net/<branch>/`.
+
+## Personas
+
+The design and content of the site should be adapted to the different people and their motivations. The following is a list of proto-personas that should be used as a guide.
+
+### Average user
+
+_... just wants access to the internet._
+
+- wants to know where the closest access point is
+- needs information about the security of the network
+- is reporting problems
+
+### Idealist
+
+_... dreaming of a hierarchy-free future of the internet._
+
+- wants to know about the structure of the mesh network and the key differences to the internet
+- is willing to support in various ways
+- sees the mesh network as the technical foundation for another future
+
+### Hobbyist
+
+_... motivated by technical interest and playfulness._
+
+- is interested in technical details
+- wants to play with the software and in the network
+- could contribute in the development
+- wants to talk/write with other geeks
+
+### Other tech communities
+
+_... searching for opportunities for cooperation._
+
+- want to meet people to talk
+- need to know what the options of cooperation are
+- run their own software in the mesh network
+- add sensors and other devices to existing locations
+
+### Location owner
+
+_... wants to provide free wifi in a secure way._
+
+- wants to be in touch with other location owners
+- needs information on legal stuff
+- not that interested in the technical stuff
+- needs to know what to do and where to ask for help if the location is down
+
+## Structure of the website
+
+When developing the structure of the website, it should also be taken into account that there are different roles of participation within the community. These exist independently of the personas, as the roles can be perceived through different motivations.
+
+| Role         | Description                                               |
+|--------------|-----------------------------------------------------------|
+| 🧑‍💻 User      | Using the network as a client.                            |
+| 🧑‍🔧 Operator  | Running and maintaining at least one node in the network. |
+| 🧑‍🔬 Developer | Working on the project in any way.                        |
+| 🦸 Suporter:  | Providing resources for the community.                    |
+
+The layout should also take into account that there are [different types of documentation](https://www.writethedocs.org/videos/eu/2017/the-four-kinds-of-documentation-and-why-you-need-to-understand-what-they-are-daniele-procida/), each of which has its own purpose and target group.
+
+- learning-oriented tutorials
+- goal-oriented how-to guides
+- understanding-oriented discussions
+- information-oriented reference material


### PR DESCRIPTION
I added a `CONTRIBUTING.md` file to explain our workflow and to have a place where the personas could be documented/developed. As we don't have the data for qualitative personas (and there are other issues with that concept), I only created some proto personas as a rough overview of different motivations. This is meant as a start. Feel free to add more details, now or later.

The _Structure of the website_ chapter now only contains the current state of the discussion. It should be updated as soon as there is more concept for the structure.

This resolves #138.