### PR TITLE
Workflows: add a comment with dev-link to PRs

### DIFF
--- a/.github/workflows/comment-dev.yml
+++ b/.github/workflows/comment-dev.yml
@@ -1,0 +1,19 @@
+---
+
+name: Comment on PR
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            This is a link to a preview of the website from this Pull Request: [dev.berlin.freifunk.net/${{ github.head_ref }}/](http://dev.berlin.freifunk.net/${{ github.head_ref }}/).


### PR DESCRIPTION
This fixes #125 

This Action [worked on my fork](https://github.com/FFHener/berlin.freifunk.net/actions/runs/8688238446/job/23823535112). It might be an acces problem on this Repo, maybe because it is newly introduced in this PR?