### PR TITLE
fix(icons): overwrite theme stylesheet to fix font path

### DIFF
--- a/assets/scss/custom/plugins/icons/_google-material.scss
+++ b/assets/scss/custom/plugins/icons/_google-material.scss
@@ -1,0 +1,14 @@
+// Overwriting the theme stylesheet to fix font path
+
+// Google Material Icon Font via
+// https://github.com/marella/material-symbols/tree/main/material-symbols
+
+
+@font-face {
+  font-family: 'Material Symbols Outlined';
+  font-weight: 400 700;
+  font-display: block;
+  font-style: normal;
+  src: local('Material Symbols Outlined'), local('Material Icons'), local('MaterialIcons-Outlined'),
+    url($material-icon-font-path) format('woff2'),
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1,4 +1,4 @@
-// Overwriting the theme stylesheet to allow custom colors
+// Overwriting the theme stylesheet to allow custom colors and set paths for icon import
 
 /* Template Name: LotusLabs Docs
    Author: Colin Wilson
@@ -12,6 +12,9 @@
 $font-family-secondary:  {{ .Site.Params.secondary_font | default "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Ubuntu'" }};
 $font-family-sans-serif: {{ .Site.Params.sans_serif_font | default "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Ubuntu'" }};
 $font-family-monospace:  {{ .Site.Params.mono_font | default "SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace" }};
+
+//Icons
+$material-icon-font-path: '{{ absURL "docs/fonts/material-symbols-outlined.woff2" }}';
 
 //Fonts
 // @import "custom/fonts/fonts";


### PR DESCRIPTION
Icon Fonts are not working on the sub pages right now. I changed the paths from relative to absolute, so that they work on every page, including the dev server. 