### PR TITLE
schema.org: add more URLs and images

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -101,6 +101,84 @@
             {
               "@type": "Article",
               "url": "https://foerderverein.freie-netzwerke.de/wp-content/uploads/sites/3/2014/06/MABB_BBB_Abschlussbericht_2013_20140331.pdf"
+            },
+            {
+              "@type": "Article",
+              "url": "https://www.berliner-zeitung.de/archiv/freies-wlan-im-test-hier-koennen-sie-in-berlin-kostenlos-im-internet-surfen-li.777572"
+            },
+            {
+              "@type": "Article",
+              "url": "https://www.zeit.de/digital/internet/2013-10/freifunk-berlin-nsa"
+            },
+            {
+              "@type": "Article",
+              "url": "https://detektor.fm/digital/internet-versorung-godspot"
+            },
+            {
+              "@type": "Article",
+              "url": "https://www.morgenpost.de/berlin/article205456747/Berliner-Freifunker-basteln-ein-freies-Internet-fuer-alle.html"
+            },
+            {
+              "@type": "Article",
+              "url": "http://kunsthalle.kunsthochschule-berlin.de/Freifunk.html"
+            },
+            {
+              "@type": "Article",
+              "url": "https://hausderstatistik.org/pioniere/freifunk/"
+            },
+            {
+              "@type": "Article",
+              "url": "https://www.linkedin.com/posts/schwarztobias_schnelles-internet-kostenlos-ja-seit-activity-7204058139812442112-ClWU/"
+            },
+            {
+              "@type": "Article",
+              "url": "https://dacosto.com/public-wifi-net/"
+            }
+          ],
+          "image": [
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://upload.wikimedia.org/wikipedia/commons/5/51/Freifunk-Initiative_in_Berlin-Kreuzberg.jpg"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://img.sparknews.funkemedien.de/205456745/205456745_1436386483_v16_9_1200.webp"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://media04.berliner-woche.de/article/2019/02/26/5/245455_XXL.jpg?1562104325"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://i0.wp.com/hausderstatistik.org/wp-content/uploads/2020/06/Freifunk-Initiative_in_Berlin.jpg"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://pbs.twimg.com/media/FTSLB-8XwAEdBGD?format=jpg&name=large"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://wiki.freifunk.net/images/7/7f/K9_BBB_NW_IMG_20131202_121908.jpg"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://wiki.freifunk.net/images/a/ab/Hds_mast_next.jpg"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://wiki.freifunk.net/images/e/ea/Provisorischer_Antennenmast.jpg"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://wiki.freifunk.net/images/f/f9/Rhxb-ostseite.jpg"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://wiki.freifunk.net/images/6/6e/K9_BBB_Schrank_mit_Tuer_IMG_20131202_123049.jpg"
+            },
+            {
+              "@type": "ImageObject",
+              "contentUrl": "https://media.licdn.com/dms/image/v2/D4D22AQFljBavJJwjlw/feedshare-shrink_2048_1536/feedshare-shrink_2048_1536/0/1719197088471?e=1729123200&v=beta&t=jazRkh0nvFJe_tOToXCs0JKCMjA_Z1c1DNlmfO3rBLk"
             }
           ]
         }


### PR DESCRIPTION
This PR adds more articles and posts that mention Freifunk Berlin and it also adds a number of images that are related to Freifunk Berlin to the markup. The intention behind all of this is to create a Google Knowledge Graph entity that will result in a better search snippet at Google.