### PR TITLE
fix: syntax - missing comma

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -67,8 +67,8 @@
             "https://www.wikidata.org/wiki/Q129176426",
             "https://github.com/freifunk-berlin/",
             "https://twitter.com/freifunk_berlin/",
-            "https://x.com/freifunk_berlin/"
-            "https://chaos.social/@freifunk_berlin",
+            "https://x.com/freifunk_berlin/",
+            "https://chaos.social/@freifunk_berlin"
           ],
           "subjectOf": [
             {


### PR DESCRIPTION
This fixes our prod builds: https://github.com/freifunk-berlin/berlin.freifunk.net/actions/runs/16094926557/job/45416525863
