### PR TITLE
fix: disable default redirect so that webserver redirects are used

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -5,6 +5,7 @@ baseURL = "https://berlin.freifunk.net"
 
 defaultContentLanguage = "de"
 defaultContentLanguageInSubdir = true
+disableDefaultLanguageRedirect = true
 
 enableRobotsTXT = true
 


### PR DESCRIPTION
This fixes freifunk-berlin/berlin.freifunk.net#188.  Depends on freifunk-berlin/ansible#201.