### PR TITLE
content: add dweb.freifunk.net sub page

### DIFF
--- a/content/dweb.en.md
+++ b/content/dweb.en.md
@@ -1,0 +1,10 @@
+---
+title: "DwebCamp 2026, powered by Freifunk"
+description: "Information about the wifi network at DwebCamp 2026 and collaboration with the Freifunk Berlin community network."
+---
+
+Find information about the DwebCamp wifi network and Berlin community networking here soon.
+
+To sign up for the Wireless Neighborhood Walks on Monday 6-Jul-2026 @ 3pm and Monday 13-Jul-2026 @ 3pm, email [dweb@stadtfunk.net](mailto:dweb@stadtfunk.net). English language, max 15 participants each date. We'll do 1 hour of walking and 1 hour of talking in the Kreuzberg and Neukölln neighborhoods.
+
+We offer variants of the walk which don't involve stairs or climbing, and with the second half in reasonably accessible cafes with Freifunk wifi ([Südblock](https://www.suedblock.org/) in Kreuzberg & [Klunkerkranich](https://klunkerkranich.org/) in Neukölln).

--- a/hugo.toml
+++ b/hugo.toml
@@ -49,9 +49,13 @@ disableKinds = ['taxonomy', 'term']
                 url = 'map/'
                 weight = 20
             [[languages.de.menus.primary]]
+                name = 'DwebCamp 2026'
+                url = 'dweb/'
+                weight = 25
+            [[languages.de.menus.primary]]
                 name = 'Spenden'
                 url = 'donate/'
-                weight = 20
+                weight = 30
             [[languages.de.menus.primary]]
                 name = 'Dokumentation'
                 url = 'docs/'
@@ -91,6 +95,10 @@ disableKinds = ['taxonomy', 'term']
                 name = 'Map'
                 url = 'map/'
                 weight = 20
+            [[languages.en.menus.primary]]
+                name = 'DwebCamp 2026'
+                url = 'dweb/'
+                weight = 25
             [[languages.en.menus.primary]]
                 name = 'Donate'
                 url = 'donate/'


### PR DESCRIPTION
Content needs expanding, but we urgently need to bring a minimum version of the page online.

Depends: https://github.com/freifunk-berlin/ansible/pull/219