### PR TITLE
content: dweb neighborhood walks moved to 4pm

### DIFF
--- a/content/dweb.en.md
+++ b/content/dweb.en.md
@@ -5,6 +5,6 @@ description: "Information about the wifi network at DwebCamp 2026 and collaborat
 
 Find information about the DwebCamp wifi network and Berlin community networking here soon.
 
-To sign up for the Wireless Neighborhood Walks on Monday 6-Jul-2026 @ 3pm and Monday 13-Jul-2026 @ 3pm, email [dweb@stadtfunk.net](mailto:dweb@stadtfunk.net). English language, max 15 participants each date. We'll do 1 hour of walking and 1 hour of talking in the Kreuzberg and Neukölln neighborhoods.
+To sign up for the Wireless Neighborhood Walks on Monday 6-Jul-2026 @ 4pm ~3pm~ and Monday 13-Jul-2026 @ 4pm ~3pm~, email [dweb@stadtfunk.net](mailto:dweb@stadtfunk.net). English language, max 15 participants each date. We'll do 1 hour of walking and 1 hour of talking in the Kreuzberg and Neukölln neighborhoods.
 
 We offer variants of the walk which don't involve stairs or climbing, and with the second half in reasonably accessible cafes with Freifunk wifi ([Südblock](https://www.suedblock.org/) in Kreuzberg & [Klunkerkranich](https://klunkerkranich.org/) in Neukölln).


### PR DESCRIPTION
Klunkerkranich and Südblock open at 5pm, so it's better to start the walks a little later at 4pm.