### PR TITLE
feat: Link #freifunk-berlin:digitale-gesellschaft.ch on contacts page

### DIFF
--- a/content/contact.de.md
+++ b/content/contact.de.md
@@ -11,7 +11,7 @@ Möglichkeiten, bei Freifunk mitzumachen, gibt es viele: als Netzwerker_in, Soft
 
 ## Chat
 
-Ein großer Teil der Berliner Community kommuniziert per Matrix: [#berlin.freifunk.net:matrix.org](https://matrix.to/#/#berlin.freifunk.net:matrix.org)
+Ein großer Teil der Berliner Community kommuniziert per Matrix! Den Hauptkanal findet man bei [#berlin.freifunk.net:matrix.org](https://matrix.to/#/#berlin.freifunk.net:matrix.org) – weitere Kanäle findet man in unserem Matrix Space bei [#freifunk-berlin:digitale-gesellschaft.ch](https://matrix.to/#/#freifunk-berlin:digitale-gesellschaft.ch).
 
 ## Mailingliste
 

--- a/content/contact.en.md
+++ b/content/contact.en.md
@@ -9,7 +9,7 @@ Time and date of the meetings of the Berlin Freifunk community can be found in t
 
 ## Chat
 
-Most of the Berlin Freifunk community communicates via Matrix: [#berlin.freifunk.net:matrix.org](https://matrix.to/#/#berlin.freifunk.net:matrix.org)
+Most of the Berlin Freifunk community communicates via Matrix! The main channel can be found at [#berlin.freifunk.net:matrix.org](https://matrix.to/#/#berlin.freifunk.net:matrix.org) – however, there are more in our Matrix space at [#freifunk-berlin:digitale-gesellschaft.ch](https://matrix.to/#/#freifunk-berlin:digitale-gesellschaft.ch).
 
 ## Mailing list
 


### PR DESCRIPTION
Only today at the Freifunk treffen have a first learnt that there is even a Freifunk space and not just the general channel.

Therefore, I am linking it on the contacts page (in both languages), so that people can find it more easily.

I've tested this on hugo, and it works fine. Lino can vouch for this.